### PR TITLE
try a workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ cache: packages
 before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
 deploy:
   provider: script
-  script: Rscript -e 'pkgdown::deploy_site_github()'
+  script: Rscript -e 'pkgdown::deploy_site_github(ssh_id = Sys.getenv("TRAVIS_DEPLOY_KEY", ""))'
   skip_cleanup: true


### PR DESCRIPTION
possible solution to the issue you describe in https://deck-chat.slack.com/archives/CHXP5SQ6R/p1583860645011400?thread_ts=1583859918.007000&cid=CHXP5SQ6R -- looks like this is a known problem with pkgdown: https://github.com/r-lib/pkgdown/issues/1206. seems like pkgdown is looking for the key in `id_rsa`. This is the workaround suggested.