### PR TITLE
Distinct on the category columns a rating is assigned

### DIFF
--- a/R/rating_get_candidate_ratings.R
+++ b/R/rating_get_candidate_ratings.R
@@ -106,8 +106,7 @@ rating_get_candidate_ratings <- function(candidate_ids,
         tidyr::drop_na(value) %>%
         # Rename categories now that we've deduped
         mutate(
-          name = elmers("category_name_{row_number()}"),
-          value = elmers("category_id_{row_number()}")
+          name = elmers("category_name_{row_number()}")
         ) %>%
         # Back to wide format
         tidyr::pivot_wider() %>%


### PR DESCRIPTION
VoteSmart returns categories that a given candidate rating is tagged with. Lots of these are duplicated, for whatever reason.

For instance,

```
  category_id category_name category_id_1 category_name_1 category_id_2 category_name_2 category_id_3 category_name_3 category_id_4 category_name_4 category_id_5
  <chr>       <chr>         <chr>         <chr>           <chr>         <chr>           <chr>         <chr>           <chr>         <chr>           <chr>        
1 2           Abortion      2             Abortion        2             Abortion        75            Abortion and R… 75            Abortion and R… 75   
```

This change takes all the categories to long, distincts on them, renames them to new category names (so we don't go from `category_1` to `category_4`, in this case), and then spreads them back out to wide format.

Currently in the `parts-dept` VS script, [we're only taking the first category](https://github.com/decktools/parts-dept/pull/99/files#diff-e7be00898a2936d7cfd9f2772e7f8293R482-R484). I think it would be useful to store more than one, although our schema wouldn't match if we inserted e.g. a chunk with 5 categories and then tried to append a chunk with 7.  We could concatenate all the categories into a string and all their ids into a string. Not sure if I like that or not.