### PR TITLE
Fix up API end of file errors by hand

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -10,7 +10,9 @@ clean_df <- function(df) {
     purrr::map_dfc(
       stringr::str_remove_all,
       '\\\"'
-    )
+    ) %>%
+    purrr::map_dfc(as.character) %>%
+    purrr::map_dfc(stringr::str_squish)
 }
 
 clean_html <- function(x,

--- a/tests/testthat/test-rating_get_candidate_ratings.R
+++ b/tests/testthat/test-rating_get_candidate_ratings.R
@@ -4,6 +4,7 @@ pelosi_id <- 26732
 obama_id <- 9490
 pete_id <- 127151
 warren_id <- 141272
+fixup_id <- 21706 # Response doesn't end with `}}`
 
 test_that("rating_get_candidate_ratings", {
   sig_ids <- c(2167, 2880)


### PR DESCRIPTION
This is a fix for the case when the VoteSmart API returns a response that doesn't end with `}}`. 

We ask for the content as text, [glue the curly braces on](https://github.com/decktools/votesmart/compare/fixup?expand=1#diff-a0a1e071b00efb92e7301e309a4e239fR31) and then use [`jsonlite::fromJSON`](https://github.com/decktools/votesmart/compare/fixup?expand=1#diff-a0a1e071b00efb92e7301e309a4e239fR32) to parse the response from text to a list. 

Unfortunately, the result is shaped differently than in the case when we can just go straight from the response to a list using `httr::content(as = "parsed")` in the usual case. So we need a different kind of reshaping for the fixup case.