### PR TITLE
Use ids supplied if we don't get them back from the API

### DIFF
--- a/R/candidates_get_by_office_state.R
+++ b/R/candidates_get_by_office_state.R
@@ -1,6 +1,6 @@
 #' Get candidates by the state in which they hold office
 #'
-#' @param state_ids Optional: vector of state abbreviations. Default is \code{NA}, for national elections.
+#' @param state_ids Optional: vector of state abbreviations. Default is \code{NA}, for national-level offices (e.g. US President and Vice President). For all other offices the \code{state_id} must be supplied.
 #' @param office_ids Required: vector of office ids that candidates hold. See \code{\link{office_get_levels}} and \code{\link{office_get_offices_by_level}} for office ids.
 #' @param election_years Optional: vector of election years in which the candidate held office. Default is the current year.
 #' @param all Boolean: should all possible combinations of the variables be searched for, or just the exact combination of them in the order they are supplied?
@@ -73,13 +73,13 @@ candidates_get_by_office_state <- function(state_ids = NA,
 
   for (i in 1:nrow(query_df)) {
     q <- query_df$query[i]
-    state_id <- query_df$state_id[i]
-    office_id <- query_df$office_id[i]
-    election_year <- query_df$election_year[i]
+    this_state_id <- query_df$state_id[i]
+    this_office_id <- query_df$office_id[i]
+    this_election_year <- query_df$election_year[i]
 
     if (verbose) {
       elmers_message(
-        "Requesting data for {{state_id: {state_id}, office_id: {office_id}, election_year: {election_year}}}."
+        "Requesting data for {{state_id: {this_state_id}, office_id: {this_office_id}, election_year: {this_election_year}}}."
       )
     }
 
@@ -110,9 +110,10 @@ candidates_get_by_office_state <- function(state_ids = NA,
       this %<>%
         mutate(
           # Sometimes these are off so set them explicitly
-          election_state_id = state_id,
-          office_id = office_id,
-          election_year = election_year,
+          office_state_id = office_state_id %>% coalesce(this_state_id),
+          election_state_id = election_state_id %>% coalesce(this_state_id),
+          office_id = office_id %>% coalesce(this_office_id),
+          election_year = election_year %>% coalesce(this_election_year),
         ) %>%
         transform_election_special() %>%
         select(

--- a/man/candidates_get_by_office_state.Rd
+++ b/man/candidates_get_by_office_state.Rd
@@ -13,7 +13,7 @@ candidates_get_by_office_state(
 )
 }
 \arguments{
-\item{state_ids}{Optional: vector of state abbreviations. Default is \code{NA}, for national elections.}
+\item{state_ids}{Optional: vector of state abbreviations. Default is \code{NA}, for national-level offices (e.g. US President and Vice President). For all other offices the \code{state_id} must be supplied.}
 
 \item{office_ids}{Required: vector of office ids that candidates hold. See \code{\link{office_get_levels}} and \code{\link{office_get_offices_by_level}} for office ids.}
 


### PR DESCRIPTION
The VoteSmart API can be a little weird/inconsistent in what it returns given a set of params supplied. In testing out the `candidates_get_by_office_state` (h/t to https://github.com/decktools/votesmart/issues/20) with

```
candidates_get_by_office_state(
    state_ids = "CA",
    office_ids = c(5, 6),
    election_years = 2017
)
```

I realized that it returned one candidate whose `office_id` was 7, not a value we supplied in the query. Other times, `office_id`s, `election_state_id`s, etc. are `NA` when we know what they should be, because we specified them in the query.

This change takes whatever ids are in the response if they exist and otherwise replaces them with the ids we supplied. This way, we keep that `office_id` of 7 (which btw appears to be [legit](https://ballotpedia.org/Wendy_Carrillo)) and otherwise return the id we think it should be.

This PR also clarifies the documentation around supplying `NA` as a `state_id` to `candidates_get_by_office_state` that was brought up in https://github.com/decktools/votesmart/issues/20! 